### PR TITLE
feat(security): add Spring Security dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,13 +26,13 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 	implementation 'org.springframework.boot:spring-boot-starter-mail'
-//	implementation 'org.springframework.boot:spring-boot-starter-security'
+	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-websocket'
 	implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:3.0.4'
-//	implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity6'
+	implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity6'
 
 	implementation 'com.github.ulisesbocchio:jasypt-spring-boot-starter:3.0.5'
 
@@ -43,7 +43,7 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter-test:3.0.4'
-//	testImplementation 'org.springframework.security:spring-security-test'
+	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	
 	/*메일*/


### PR DESCRIPTION
## Part
- [ ] FE
- [x] BE
- [ ] Other

---

## 작업 내용
- Spring Security 의존성을 추가했습니다.
- 세 가지 의존성을 추가했습니다:
  - `spring-boot-starter-security`
  - `thymeleaf-extras-springsecurity6`
  - `spring-security-test`
- 의존성 추가로 SecurityConfig 클래스와 관련 보안 설정이 정상 작동할 수 있게 되었습니다.

---

## 관련 이슈
- #N/A (관련 이슈 번호가 있다면 추가해주세요)

---

## Jira 링크
- [OCS-001](https://your-jira.atlassian.net/browse/OCS-001)

---

## 공유사항
- 기존에 주석 처리되어 있던 Spring Security 의존성을 활성화하여 컴파일 오류를 해결했습니다.
- 이 변경으로 인해 보안 관련 설정이 활성화되므로, 로그인 기능이 영향을 받을 수 있습니다.
- 추후 SecurityConfig 클래스에서 보안 설정을 필요에 맞게 조정해야 할 수 있습니다.

---

## PR 등록 전 확인사항
- [ ] 관련 이슈 작성
- [x] 작업 내용 정리 완료
- [x] 공유사항 기입
- [x] 테스트 여부 확인