### PR TITLE
fix: Mapper 스캐닝 설정 및 UserMapper 구현

### DIFF
--- a/src/main/java/kr/or/kosa/visang/config/MyBatisConfig.java
+++ b/src/main/java/kr/or/kosa/visang/config/MyBatisConfig.java
@@ -4,7 +4,16 @@ import org.mybatis.spring.annotation.MapperScan;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
-@MapperScan(basePackages = {"kr.or.kosa.visang.domain.contract.repository", "kr.or.kosa.visang.domain.agent.repository"})
+@MapperScan(basePackages = {
+    "kr.or.kosa.visang.domain.contract.repository", 
+    "kr.or.kosa.visang.domain.agent.repository",
+    "kr.or.kosa.visang.domain.user.repository",
+    "kr.or.kosa.visang.domain.admin.repository",
+    "kr.or.kosa.visang.domain.client.repository",
+    "kr.or.kosa.visang.domain.invitation.repository",
+    "kr.or.kosa.visang.domain.company.repository",
+    "kr.or.kosa.visang.domain.contractTemplate.repository"
+})
 public class MyBatisConfig {
     // MyBatis 추가 설정이 필요하면 여기에 추가
 } 

--- a/src/main/resources/mapper/ContractMapper.xml
+++ b/src/main/resources/mapper/ContractMapper.xml
@@ -185,12 +185,6 @@
         ORDER BY contract_time DESC
     </select>
 
-    <select id="selectContractById" resultMap="ContractResultMap">
-        SELECT *
-        FROM contract
-        WHERE contract_id = #{id}
-    </select>
-
     <!-- 모든 계약 조회 -->
     <select id="selectAllContracts" resultMap="ContractResultMap">
         SELECT <include refid="baseColumns" />,

--- a/src/main/resources/mapper/UserMapper.xml
+++ b/src/main/resources/mapper/UserMapper.xml
@@ -14,6 +14,63 @@
             END AS user_type
     </select>
     
+    <!-- 이메일로 사용자 조회 -->
+    <select id="findByEmail" parameterType="string" resultMap="userResultMap">
+        SELECT
+            'CLIENT' AS user_type,
+            client_id AS id,
+            name,
+            email,
+            password,
+            phone_number,
+            address,
+            role,
+            email_verified,
+            created_at,
+            updated_at,
+            verification_code
+        FROM clients
+        WHERE email = #{email}
+        
+        UNION ALL
+        
+        SELECT
+            'AGENT' AS user_type,
+            agent_id AS id,
+            name,
+            email,
+            password,
+            phone_number,
+            address,
+            role,
+            email_verified,
+            created_at,
+            updated_at,
+            verification_code
+        FROM agents
+        WHERE email = #{email}
+        
+        UNION ALL
+        
+        SELECT
+            'ADMIN' AS user_type,
+            admin_id AS id,
+            name,
+            email,
+            password,
+            phone_number,
+            address,
+            role,
+            email_verified,
+            created_at,
+            updated_at,
+            verification_code
+        FROM admins
+        WHERE email = #{email}
+        
+        LIMIT 1
+    </select>
+    
     <!-- 이메일 중복 확인 -->
     <select id="countByEmail" resultType="int">
         SELECT


### PR DESCRIPTION

# fix: Mapper 스캐닝 설정 및 UserMapper 구현

## Part
- [ ] FE
- [x] BE
- [ ] Other

---

## 작업 내용
- 마이바티스 MapperScan 설정에 누락된 패키지들을 추가하여 모든 매퍼 인터페이스가 정상적으로 스캔되도록 수정했습니다.
- UserMapper 인터페이스에 선언되어 있지만 XML에 구현이 누락되어 있던 findByEmail 메서드를 구현했습니다.
- ContractMapper.xml에서 중복 정의된 selectContractById 쿼리를 제거했습니다.
- 애플리케이션 시작 시 CustomUserDetailsService의 UserMapper 의존성 주입 문제를 해결했습니다.

---

## 관련 이슈
- 스프링 애플리케이션 시작 시 실패하는 의존성 주입 문제 해결

---

## Jira 링크
- [OCS-47](https://your-jira.atlassian.net/browse/OCS-47)

---

## 공유사항
- 마이바티스 설정 파일에서 다루는 도메인들이 일부만 스캔 설정되어 있어 UserMapper와 같은 일부 인터페이스들이 빈으로 등록되지 않는 문제가 있었습니다.
- 모든 리포지토리 패키지를 스캔하도록 수정하고, 누락된 UserMapper의 findByEmail 구현을 추가했습니다.
- ContractMapper.xml에 중복된 쿼리 정의가 있어 이를 제거했습니다.

---

## PR 등록 전 확인사항
- [x] 관련 이슈 작성
- [x] 작업 내용 정리 완료
- [x] 공유사항 기입
- [x] 테스트 여부 확인
