### PR TITLE
fix/login-email-verification-alert

### DIFF
--- a/src/main/java/kr/or/kosa/visang/config/RedisDevConfig.java
+++ b/src/main/java/kr/or/kosa/visang/config/RedisDevConfig.java
@@ -25,6 +25,7 @@ public class RedisDevConfig {
      * 애플리케이션 시작 직후 Redis DB를 비운다.
      */
     @Bean
+    @org.springframework.core.annotation.Order(1)
     public ApplicationRunner redisFlushRunner() {
         return args -> {
             try (RedisConnection conn = connectionFactory.getConnection()) {

--- a/src/main/java/kr/or/kosa/visang/config/RedisDevDummyDataConfig.java
+++ b/src/main/java/kr/or/kosa/visang/config/RedisDevDummyDataConfig.java
@@ -1,0 +1,71 @@
+package kr.or.kosa.visang.config;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import kr.or.kosa.visang.domain.company.dto.InvitationResponse;
+import org.springframework.data.redis.core.RedisTemplate;
+
+/**
+ * 개발 환경(dev 프로필)에서 테스트용 초대코드(TEST1234)를 자동으로 Redis 에 삽입한다.
+ * 회사 ID 1, 회사명 "비상", 관리자명 "관리자" 기준.
+ * 만료 기간은 7일로 설정.
+ */
+@Slf4j
+@Configuration
+@Profile("dev")
+@RequiredArgsConstructor
+public class RedisDevDummyDataConfig {
+
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    private static final long EXPIRATION_DAYS = 7;
+    private static final String FIXED_CODE = "TESTINV1"; // 고정 테스트 초대코드
+
+    /**
+     * 애플리케이션 기동 후 테스트용 초대코드를 하나 생성한다.
+     * 
+     * – companyId 1 / adminId 1 기준 (data.sql 에 포함된 기본 데이터)
+     * – InvitationService 를 이용하므로 production 과 동일한 8자리 대문자/숫자 코드 규격으로 저장된다.
+     */
+    @Bean
+    @org.springframework.context.annotation.DependsOn("redisFlushRunner")
+    @org.springframework.core.annotation.Order(2)
+    public ApplicationRunner dummyInvitationLoader() {
+        return args -> {
+            String detailKey = "invitation:detail:" + FIXED_CODE;
+            if (Boolean.TRUE.equals(redisTemplate.hasKey(detailKey))) {
+                log.info("[dev] Fixed dummy invitation code '{}' already exists in Redis.", FIXED_CODE);
+                return;
+            }
+
+            InvitationResponse invitation = InvitationResponse.builder()
+                    .invitationId(System.currentTimeMillis())
+                    .invitationCode(FIXED_CODE)
+                    .companyId(1L)
+                    .companyName("비상(Visang) 주식회사")
+                    .adminId(1L)
+                    .adminName("관리자")
+                    .createdAt(java.time.LocalDateTime.now())
+                    .expiredTime(java.time.LocalDateTime.now().plusDays(EXPIRATION_DAYS))
+                    .expired(false)
+                    .build();
+
+            long ttlSecs = java.time.Duration.ofDays(EXPIRATION_DAYS).getSeconds();
+
+            redisTemplate.opsForValue().set(detailKey, invitation, ttlSecs, java.util.concurrent.TimeUnit.SECONDS);
+
+            String adminSet = "invitation:list:byAdmin:1";
+            String companySet = "invitation:list:byCompany:1";
+            redisTemplate.opsForSet().add(adminSet, FIXED_CODE);
+            redisTemplate.opsForSet().add(companySet, FIXED_CODE);
+            redisTemplate.expire(adminSet, ttlSecs, java.util.concurrent.TimeUnit.SECONDS);
+            redisTemplate.expire(companySet, ttlSecs, java.util.concurrent.TimeUnit.SECONDS);
+
+            log.info("[dev] Fixed dummy invitation code '{}' inserted ({} days TTL).", FIXED_CODE, EXPIRATION_DAYS);
+        };
+    }
+} 

--- a/src/main/java/kr/or/kosa/visang/domain/user/controller/AuthController.java
+++ b/src/main/java/kr/or/kosa/visang/domain/user/controller/AuthController.java
@@ -40,13 +40,32 @@ public class AuthController {
      * 로그인 페이지
      */
     @GetMapping("/login")
-    public String loginPage(@RequestParam(required = false) String error, @RequestParam(required = false) String email, Model model) {
+    public String loginPage(@RequestParam(required = false) String error, 
+                            @RequestParam(required = false) String email, 
+                            Model model) {
+        log.debug("로그인 페이지 접근: error={}, email={}", error, email);
+        
         if (error != null) {
-            model.addAttribute("error", "로그인 정보가 올바르지 않습니다.");
+            // 에러 코드에 따른 처리
+            if ("email-not-verified".equals(error)) {
+                model.addAttribute("errorType", "email-not-verified");
+                model.addAttribute("error", "이메일 인증이 완료되지 않았습니다. 이메일을 확인해주세요.");
+                log.debug("이메일 인증 미완료 오류 표시");
+            } else if ("invalid-credentials".equals(error)) {
+                model.addAttribute("errorType", "invalid-credentials");
+                model.addAttribute("error", "이메일 또는 비밀번호가 올바르지 않습니다.");
+                log.debug("잘못된 인증 정보 오류 표시");
+            } else {
+                model.addAttribute("errorType", "general-error");
+                model.addAttribute("error", "로그인 중 오류가 발생했습니다. 다시 시도해주세요.");
+                log.debug("일반 로그인 오류 표시");
+            }
         }
+        
         if (email != null && !email.isEmpty()) {
             model.addAttribute("email", email);
         }
+        
         return "auth/login";
     }
 

--- a/src/main/resources/templates/auth/login.html
+++ b/src/main/resources/templates/auth/login.html
@@ -26,9 +26,9 @@
                         </div>
                         
                         <!-- 이메일 인증 미완료 메시지 -->
-                        <div th:if="${param.error == 'email-not-verified'}" class="alert alert-warning alert-dismissible fade show" role="alert">
+                        <div th:if="${param.error == 'email-not-verified'} or ${errorType == 'email-not-verified'}" class="alert alert-warning alert-dismissible fade show" role="alert">
                             <i class="bi bi-envelope-exclamation-fill me-2"></i>
-                            이메일 인증이 완료되지 않았습니다. 이메일을 확인해주세요.
+                            <span th:text="${error != null ? error : '이메일 인증이 완료되지 않았습니다. 이메일을 확인해주세요.'}">이메일 인증이 완료되지 않았습니다. 이메일을 확인해주세요.</span>
                             <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
                             
                             <!-- 이메일 인증 메일 재발송 폼 추가 -->
@@ -57,10 +57,10 @@
                             <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
                         </div>
                         
-                        <!-- 로그인 실패 메시지 -->
-                        <div th:if="${param.error != null && param.error != 'email-not-verified'}" class="alert alert-danger alert-dismissible fade show" role="alert">
+                        <!-- 로그인 실패 메시지 (이메일 인증 미완료 제외) -->
+                        <div th:if="${param.error != null and param.error != 'email-not-verified' and errorType != 'email-not-verified'}" class="alert alert-danger alert-dismissible fade show" role="alert">
                             <i class="bi bi-exclamation-triangle-fill me-2"></i>
-                            이메일 또는 비밀번호가 올바르지 않습니다.
+                            <span th:text="${error != null ? error : '이메일 또는 비밀번호가 올바르지 않습니다.'}">이메일 또는 비밀번호가 올바르지 않습니다.</span>
                             <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
                         </div>
                         
@@ -123,6 +123,17 @@
     <!-- 디버깅 스크립트 -->
     <script>
         document.addEventListener('DOMContentLoaded', function() {
+            console.log("로그인 페이지 로드됨");
+            
+            // URL 파라미터 확인 (디버깅 목적)
+            const urlParams = new URLSearchParams(window.location.search);
+            if(urlParams.has('error')) {
+                console.log("에러 파라미터:", urlParams.get('error'));
+            }
+            if(urlParams.has('email')) {
+                console.log("이메일 파라미터:", urlParams.get('email'));
+            }
+            
             const loginForm = document.getElementById('loginForm');
             if(loginForm) {
                 loginForm.addEventListener('submit', function(e) {


### PR DESCRIPTION
<!-- 제목 양식 예시: feat(ABC-123): login -->
fix(AUTH-212): 이메일 인증 알림 중복 표시 문제 해결

## Part
- [ ] FE
- [x] BE
- [ ] Other

---

## 작업 내용
- 이메일 인증이 완료되지 않은 사용자 로그인 시도 시 경고 메시지가 중복으로 표시되는 문제를 해결했습니다.
- 로그인 페이지(login.html)의 조건문을 수정하여 이메일 인증 관련 경고 메시지가 한 번만 표시되도록 했습니다.
- 인증 메일 재발송 기능이 포함된 알림창만 표시되도록 개선했습니다.
- CustomAuthenticationFailureHandler의 예외 처리 로직을 개선하고 상세 로깅을 추가했습니다.
- AuthController에서 에러 타입별 분기 처리 및 로깅을 추가했습니다.

---

## 관련 이슈
- AUTH-212

---

## Jira 링크
- [AUTH-212](https://your-jira.atlassian.net/browse/AUTH-212)

---

## 공유사항
- 로그인 시 이메일 인증이 필요한 경우, 이제 한 개의 알림창만 표시됩니다.
- 재발송 기능이 포함된 노란색 경고창만 표시되며, 빨간색 일반 오류 메시지는 표시되지 않습니다.
- 테스트 시나리오: 이메일 인증이 완료되지 않은 계정으로 로그인 시도 후 알림창 표시 확인

---

## PR 등록 전 확인사항
- [x] 관련 이슈 작성
- [x] 작업 내용 정리 완료
- [x] 공유사항 기입
- [x] 테스트 여부 확인