### PR TITLE
feat(config): 여러 프로필을 지원하도록 Redis 개발 구성 확장

### DIFF
--- a/src/main/java/kr/or/kosa/visang/config/RedisDevConfig.java
+++ b/src/main/java/kr/or/kosa/visang/config/RedisDevConfig.java
@@ -15,7 +15,7 @@ import org.springframework.data.redis.connection.RedisConnectionFactory;
  */
 @Slf4j
 @Configuration
-@Profile("dev")
+@Profile({"dev", "h2", "oracle"})
 @RequiredArgsConstructor
 public class RedisDevConfig {
 


### PR DESCRIPTION
# feat(config): Redis 개발 설정을 다중 프로파일에서 지원하도록 확장

## Part
- [ ] FE
- [x] BE
- [ ] Other

---

## 작업 내용
- Redis 개발 설정(RedisDevConfig)을 여러 프로파일에서 사용할 수 있도록 확장
- @Profile("dev")를 @Profile({"dev", "h2", "oracle"})로 변경
- 애플리케이션 시작 시 Redis DB 초기화가 dev, h2, oracle 프로파일에서 모두 동작하도록 개선
- 프로파일 간 일관된 개발 환경 제공으로 Redis 상태 관리 향상

---

## 관련 이슈
- Redis 설정이 특정 프로파일에서만 동작하여 다중 환경 지원 부족 문제 해결

---

## Jira 링크
- 

---

## 공유사항
- 다중 프로파일 지원으로 개발/테스트 환경의 일관성 확보
- 기존 dev 프로파일 동작에는 영향 없음
- h2, oracle 프로파일 사용 시에도 Redis 초기화 기능 활용 가능

---

## PR 등록 전 확인사항
- [x] 관련 이슈 작성
- [x] 작업 내용 정리 완료
- [x] 공유사항 기입
- [x] 테스트 여부 확인

## 변경사항 상세
**파일**: `src/main/java/kr/or/kosa/visang/config/RedisDevConfig.java`

**변경 전**:
```java
@Profile("dev")
```

**변경 후**:
```java
@Profile({"dev", "h2", "oracle"})
```

**목적**: Redis 개발 설정을 여러 프로파일 환경에서 공통으로 사용하여 일관된 Redis 초기화 환경 제공