### PR TITLE
fix(mybatis): resolve MapperScan scope issue causing service class mapping error 

### DIFF
--- a/src/main/java/kr/or/kosa/visang/VisangApplication.java
+++ b/src/main/java/kr/or/kosa/visang/VisangApplication.java
@@ -1,15 +1,11 @@
 package kr.or.kosa.visang;
 
-import org.mybatis.spring.annotation.MapperScan;
 import org.springframework.boot.SpringApplication;
-
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-
 import com.ulisesbocchio.jasyptspringboot.annotation.EnableEncryptableProperties;
 
 @SpringBootApplication
 @EnableEncryptableProperties
-@MapperScan("kr.or.kosa.visang.domain")
 public class VisangApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/kr/or/kosa/visang/config/MyBatisConfig.java
+++ b/src/main/java/kr/or/kosa/visang/config/MyBatisConfig.java
@@ -12,7 +12,8 @@ import org.springframework.context.annotation.Configuration;
     "kr.or.kosa.visang.domain.client.repository",
     "kr.or.kosa.visang.domain.invitation.repository",
     "kr.or.kosa.visang.domain.company.repository",
-    "kr.or.kosa.visang.domain.contractTemplate.repository"
+    "kr.or.kosa.visang.domain.contractTemplate.repository",
+    "kr.or.kosa.visang.domain.chat.repository"
 })
 public class MyBatisConfig {
     // MyBatis 추가 설정이 필요하면 여기에 추가


### PR DESCRIPTION
<!-- 제목: fix(mybatis): resolve MapperScan scope issue causing service class mapping error -->

## Part
- [ ] FE
- [x] BE
- [ ] Other

---

## 작업 내용
- **문제**: MyBatis MapperScan 설정 문제로 UserService 클래스가 매퍼로 잘못 인식되어 "Invalid bound statement (not found): kr.or.kosa.visang.domain.user.service.UserService.register" 오류 발생
- **해결**: VisangApplication.java의 과도한 @MapperScan 범위 제거하고 MyBatisConfig.java에서 구체적인 repository 패키지만 스캔하도록 수정
- **추가**: 누락된 chat.repository 패키지를 MyBatisConfig.java에 추가
- **결과**: 서비스 레이어와 레포지토리 레이어의 명확한 분리로 회원가입 기능 정상화

---

## 관련 이슈
- MyBatis 매퍼 스캔 범위 문제로 인한 UserService.register 메서드 매핑 오류 해결
- 서비스 클래스가 매퍼로 인식되어 발생하는 "Invalid bound statement" 오류 수정

---

## Jira 링크
- (해당 없음)

---

## 공유사항
- **중요**: MyBatis MapperScan 범위를 구체적으로 지정하여 서비스 클래스와 매퍼 클래스의 혼동 방지
- **성능 개선**: 불필요한 클래스 스캔 방지로 애플리케이션 시작 속도 개선
- **아키텍처**: 레이어 간 명확한 분리로 코드 구조 개선
- **테스트**: 회원가입 기능이 정상적으로 작동하는지 확인 필요

---

## PR 등록 전 확인사항
- [x] 관련 이슈 작성
- [x] 작업 내용 정리 완료
- [x] 공유사항 기입
- [x] 테스트 여부 확인 (수동 테스트 권장)